### PR TITLE
feat: multi file editor

### DIFF
--- a/src/main/java/io/kestra/storage/azure/AzureFileAttributes.java
+++ b/src/main/java/io/kestra/storage/azure/AzureFileAttributes.java
@@ -1,0 +1,38 @@
+package io.kestra.storage.azure;
+
+import com.azure.storage.blob.models.BlobProperties;
+import io.kestra.core.storages.FileAttributes;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class AzureFileAttributes implements FileAttributes {
+
+    String fileName;
+    BlobProperties properties;
+    boolean isDirectory;
+
+    @Override
+    public long getLastModifiedTime() {
+        return properties.getLastModified().toEpochSecond();
+    }
+
+    @Override
+    public long getCreationTime() {
+        return properties.getCreationTime().toEpochSecond();
+    }
+
+    @Override
+    public FileType getType() {
+        if (isDirectory) {
+            return FileType.Directory;
+        }
+        return FileType.File;
+    }
+
+    @Override
+    public long getSize() {
+        return properties.getBlobSize();
+    }
+}

--- a/src/main/java/io/kestra/storage/azure/AzureStorage.java
+++ b/src/main/java/io/kestra/storage/azure/AzureStorage.java
@@ -1,22 +1,26 @@
 package io.kestra.storage.azure;
 
+import com.azure.core.util.polling.SyncPoller;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
-import com.azure.storage.blob.models.BlobStorageException;
-import com.azure.storage.blob.models.ListBlobsOptions;
-import com.google.common.collect.Streams;
+import com.azure.storage.blob.models.*;
+import io.kestra.core.storages.FileAttributes;
 import io.kestra.core.storages.StorageInterface;
 import io.micronaut.core.annotation.Introspected;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import org.apache.commons.lang3.StringUtils;
 
+import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Objects;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
 
@@ -24,6 +28,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 @AzureStorageEnabled
 @Introspected
 public class AzureStorage implements StorageInterface {
+    private static final String DIRECTORY_MARKER_FILE = ".kestradirectory";
     @Inject
     AzureClientFactory factory;
 
@@ -49,8 +54,34 @@ public class AzureStorage implements StorageInterface {
 
             return blobClient.openInputStream();
         } catch (BlobStorageException e) {
-            throw new IOException(e);
+            throw reThrowBlobStorageException(uri, e);
         }
+    }
+
+    @Override
+    public List<FileAttributes> list(String tenantId, URI uri) throws IOException {
+        String path = getPath(tenantId, uri);
+        String prefix = (path.endsWith("/")) ? path : path + "/";
+
+        if (!client().getBlobClient(prefix).exists()) {
+            throw new FileNotFoundException(uri + " (Not Found)");
+        }
+
+        ListBlobsOptions listBlobsOptions = new ListBlobsOptions()
+            .setPrefix(prefix)
+            .setDetails(new BlobListDetails().setRetrieveDeletedBlobs(false).setRetrieveSnapshots(false));
+
+        return this.client().listBlobsByHierarchy("/", listBlobsOptions, null).stream()
+            .map(BlobItem::getName)
+            .filter(key -> {
+                key = "/" + key;
+                key = key.substring(prefix.length());
+                // Remove recursive result and requested dir
+                return !key.isEmpty() && !Objects.equals(key, prefix)
+                    && !key.endsWith(DIRECTORY_MARKER_FILE);
+            })
+            .map(throwFunction(this::getFileAttributes))
+            .toList();
     }
 
     @Override
@@ -74,7 +105,7 @@ public class AzureStorage implements StorageInterface {
 
             return blobClient.getProperties().getBlobSize();
         } catch (BlobStorageException e) {
-            throw new IOException(e);
+            throw reThrowBlobStorageException(uri, e);
         }
     }
 
@@ -89,39 +120,120 @@ public class AzureStorage implements StorageInterface {
 
             return blobClient.getProperties().getLastModified().toInstant().toEpochMilli();
         } catch (BlobStorageException e) {
-            throw new IOException(e);
+            throw reThrowBlobStorageException(uri, e);
         }
+    }
+
+    @Override
+    public FileAttributes getAttributes(String tenantId, URI uri) throws IOException {
+        String path = getPath(tenantId, uri);
+        return getFileAttributes(path);
+    }
+
+    private FileAttributes getFileAttributes(String path) throws FileNotFoundException {
+        String fileName = Path.of(path).getFileName().toString();
+
+        BlobClient blobClient = this.client().getBlobClient(path);
+        if (!path.endsWith("/")) {
+            BlobClient dirBlobClient = this.client().getBlobClient(path + "/" + DIRECTORY_MARKER_FILE);
+            if (dirBlobClient.exists()) {
+                path += "/";
+                blobClient = dirBlobClient;
+            }
+        }
+        if (!blobClient.exists()) {
+            throw new FileNotFoundException(fileName + " (File not found)");
+        }
+
+        return AzureFileAttributes.builder()
+            .fileName(fileName)
+            .isDirectory(path.endsWith("/") || path.endsWith(DIRECTORY_MARKER_FILE))
+            .properties(blobClient.getProperties())
+            .build();
     }
 
     @Override
     public URI put(String tenantId, URI uri, InputStream data) throws IOException {
         try {
-            BlobClient blobClient = this.blob(getURI(tenantId, uri));
-
+            URI path = getURI(tenantId, uri);
+            BlobClient blobClient = this.blob(path);
+            mkdirs(path.getPath());
             try (data) {
                 blobClient.upload(data, true);
             }
 
             return URI.create("kestra://" + uri.getPath());
         } catch (BlobStorageException e) {
-            throw new IOException(e);
+            throw reThrowBlobStorageException(uri, e);
         }
     }
 
     public boolean delete(String tenantId, URI uri) throws IOException {
-        try {
-            BlobClient blobClient = this.blob(getURI(tenantId, uri));
-
-            if (!blobClient.exists()) {
-                return false;
-            }
-
-            blobClient.delete();
-
-            return true;
-        } catch (BlobStorageException e) {
-            throw new IOException(e);
+        String path = getPath(tenantId, uri);
+        if (isDir(path)) {
+            return !deleteByPrefix(tenantId, uri).isEmpty();
         }
+        BlobClient blobClient = this.client().getBlobClient(path);
+        if (!blobClient.exists()) {
+            return false;
+        }
+        blobClient.delete();
+        return true;
+    }
+
+    @Override
+    public URI createDirectory(String tenantId, URI uri) throws IOException {
+        String path = getPath(tenantId, uri);
+        if (!StringUtils.endsWith(path, "/")) {
+            path += "/";
+        }
+        mkdirs(path + DIRECTORY_MARKER_FILE);
+        return URI.create("kestra://" + uri.getPath());
+    }
+
+    private void mkdirs(String path) throws IOException {
+        if (!path.endsWith("/") && path.lastIndexOf('/') > 0) {
+            path = path.substring(0, path.lastIndexOf('/') + 1);
+        }
+
+        path += DIRECTORY_MARKER_FILE;
+
+        try {
+            BlobClient blobClient = this.blob(URI.create(path));
+            blobClient.upload(new ByteArrayInputStream(new byte[]{}), true);
+        } catch (BlobStorageException e) {
+            throw reThrowBlobStorageException(URI.create(path), e);
+        }
+    }
+
+    @Override
+    public URI move(String tenantId, URI from, URI to) throws IOException {
+        if (!exists(tenantId, from)) {
+            throw new FileNotFoundException(from + " (File not found)");
+        }
+
+        String source = getPath(tenantId, from);
+        String dest = getPath(tenantId, to);
+
+        BlobContainerClient client = this.client();
+
+        ListBlobsOptions listBlobsOptions = new ListBlobsOptions()
+            .setPrefix(getPath(tenantId, from))
+            .setDetails(new BlobListDetails().setRetrieveDeletedBlobs(false).setRetrieveSnapshots(false));
+        for (BlobItem itemResult : client.listBlobs(listBlobsOptions, Duration.ofSeconds(30))) {
+            if (isDir(itemResult.getName())) {
+                // do not copy directories
+                continue;
+            }
+            String destName = dest + itemResult.getName().substring(source.substring(1).length());
+            mkdirs(dest);
+            BlobClient sourceClient = client.getBlobClient(itemResult.getName());
+            SyncPoller<BlobCopyInfo, Void> poller = client.getBlobClient(destName).beginCopy(sourceClient.getBlobUrl(),
+                Duration.ofSeconds(30));
+            poller.waitForCompletion();
+        }
+        deleteByPrefix(tenantId, from);
+        return URI.create("kestra://" + from.getPath());
     }
 
     @Override
@@ -129,41 +241,79 @@ public class AzureStorage implements StorageInterface {
         try {
             BlobContainerClient client = this.client();
 
-            ListBlobsOptions listBlobsOptions = new ListBlobsOptions();
-            listBlobsOptions.setPrefix(getURI(tenantId, storagePrefix).getPath());
+            String path = getPath(tenantId, storagePrefix);
+            if (!path.endsWith("/")) {
+                path += "/";
+            }
+            ListBlobsOptions listBlobsOptions = new ListBlobsOptions()
+                .setPrefix(path)
+                .setDetails(new BlobListDetails().setRetrieveDeletedBlobs(false).setRetrieveSnapshots(false));
 
-            List<String> deleted = Streams
-                .stream(client.listBlobs(listBlobsOptions, Duration.ofSeconds(30)))
-                .filter(blobItem -> blobItem.getProperties().getContentType() != null)
-                .map(throwFunction(itemResult -> {
-                    try {
-                        return itemResult.getName();
-                    } catch (Throwable e) {
-                        throw new IOException(e);
-                    }
-                }))
-                .collect(Collectors.toList());
+            List<String> deleted = new ArrayList<>();
+            List<String> directories = new ArrayList<>();
+            for (BlobItem itemResult : client.listBlobs(listBlobsOptions, Duration.ofSeconds(30))) {
+                String name = itemResult.getName();
+                Boolean isDir = isDir(name);
+                if (isDir) {
+                    directories.add(name);
+                    continue;
+                }
+                BlobClient blobClient = this.client().getBlobClient(name);
+                blobClient.delete();
+                if (!name.endsWith(DIRECTORY_MARKER_FILE)) {
+                    // We do not want to output the hidden file we use to mark directory as deleted
+                    deleted.add(name);
+                }
+            }
 
-            deleted
-                .forEach(s -> {
-                    BlobClient blobClient = this.blob(URI.create(s));
-                    blobClient.delete();
-                });
+            // also remove main directory (we have to remove start and ending /)
+            directories.add(path.substring(1, path.length() - 1));
+            directories.sort((s1, s2) -> s2.length() - s1.length());
+            for (String directory : directories) {
+                BlobClient blobClient = this.client().getBlobClient(directory);
+                blobClient.delete();
+                deleted.add(directory);
+            }
 
-
-            return deleted
-                .stream()
+            return deleted.stream()
                 .map(s -> URI.create("kestra:///" + s.replace(tenantId + "/", "")))
-                .collect(Collectors.toList());
+                .toList();
         } catch (BlobStorageException e) {
+            if (e.getErrorCode() == BlobErrorCode.BLOB_NOT_FOUND || e.getErrorCode() == BlobErrorCode.RESOURCE_NOT_FOUND) {
+                return List.of();
+            }
             throw new IOException(e);
         }
     }
 
-    private URI getURI(String tenantId, URI uri) {
-        if (tenantId == null) {
-            return URI.create(uri.getPath());
+    private Boolean isDir(String path) {
+        // To check if a path is in fact a directory we check if our hidden file exists inside it
+        return this.client().getBlobClient(path + "/" + DIRECTORY_MARKER_FILE).exists();
+    }
+
+    private IOException reThrowBlobStorageException(URI storagePrefix, BlobStorageException e) {
+        if (e.getErrorCode() == BlobErrorCode.BLOB_NOT_FOUND || e.getErrorCode() == BlobErrorCode.RESOURCE_NOT_FOUND) {
+            return new FileNotFoundException(storagePrefix + " (File not found)");
         }
-        return URI.create("/" + tenantId + uri.getPath());
+        return new IOException(e);
+    }
+
+    private URI getURI(String tenantId, URI uri) {
+        return URI.create(getPath(tenantId, uri));
+    }
+
+    private String getPath(String tenantId, URI uri) {
+        parentTraversalGuard(uri);
+        if (tenantId == null) {
+            return uri.getPath();
+        }
+        return "/" + tenantId + uri.getPath();
+    }
+
+    // Traversal does not work with azure but it just return empty objects so throwing is more explicit
+    private void parentTraversalGuard(URI uri) {
+        if (uri.toString().contains("..")) {
+            throw new IllegalArgumentException("File should be accessed with their full path and not using relative '..' path.");
+        }
     }
 }

--- a/src/test/java/io/kestra/storage/azure/AzureStorageTest.java
+++ b/src/test/java/io/kestra/storage/azure/AzureStorageTest.java
@@ -1,76 +1,108 @@
 package io.kestra.storage.azure;
 
 import com.google.common.io.CharStreams;
+import io.kestra.core.storages.FileAttributes;
+import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.utils.IdUtils;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
-import io.kestra.core.storages.StorageInterface;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.net.URI;
-import java.net.URL;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
-import jakarta.inject.Inject;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @MicronautTest
 class AzureStorageTest {
+    private static final String contentString = "Content";
+
     @Inject
-    StorageInterface storageInterface;
+    protected StorageInterface storageInterface;
 
-    private URI putFile(String tenantId, URL resource, String path) throws Exception {
-        return storageInterface.put(
-            tenantId,
-            new URI(path),
-            new FileInputStream(Objects.requireNonNull(resource).getFile())
-        );
-    }
 
+    //region test GET
     @Test
     void get() throws Exception {
         String prefix = IdUtils.create();
         String tenantId = IdUtils.create();
-
         get(tenantId, prefix);
     }
 
     @Test
     void getNoTenant() throws Exception {
         String prefix = IdUtils.create();
-        String tenantId = IdUtils.create();
+        String tenantId = null;
 
         get(tenantId, prefix);
     }
 
-    private void get(String tenantId, String prefix) throws Exception {
-        URL resource = AzureStorageTest.class.getClassLoader().getResource("application.yml");
-        String content = CharStreams.toString(new InputStreamReader(new FileInputStream(Objects.requireNonNull(resource).getFile())));
+    @Test
+    void getNoCrossTenant() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
 
-        this.putFile(tenantId, resource, "/" + prefix + "/storage/get.yml");
+        String withTenant = "/" + prefix + "/storage/withtenant.yml";
+        putFile(tenantId, withTenant);
+        String nullTenant = "/" + prefix + "/storage/nulltenant.yml";
+        putFile(null, nullTenant);
 
-        URI item = new URI("/" + prefix + "/storage/get.yml");
-        InputStream get = storageInterface.get(tenantId, item);
-        assertThat(CharStreams.toString(new InputStreamReader(get)), is(content));
-        assertTrue(storageInterface.exists(tenantId, item));
-        assertThat(storageInterface.size(tenantId, item), is((long) content.length()));
-        assertThat(storageInterface.lastModifiedTime(tenantId, item), notNullValue());
+        URI with = new URI(withTenant);
+        InputStream get = storageInterface.get(tenantId, with);
+        assertThat(CharStreams.toString(new InputStreamReader(get)), is(contentString));
+        assertTrue(storageInterface.exists(tenantId, with));
+        assertThrows(FileNotFoundException.class, () -> storageInterface.get(null, with));
 
-        InputStream getScheme = storageInterface.get(tenantId, new URI("kestra:///" + prefix + "/storage/get.yml"));
-        assertThat(CharStreams.toString(new InputStreamReader(getScheme)), is(content));
+        URI without = new URI(nullTenant);
+        get = storageInterface.get(null, without);
+        assertThat(CharStreams.toString(new InputStreamReader(get)), is(contentString));
+        assertTrue(storageInterface.exists(null, without));
+        assertThrows(FileNotFoundException.class, () -> storageInterface.get(tenantId, without));
+
     }
 
     @Test
-    void missing() {
+    void getWithScheme() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        putFile(tenantId, "/" + prefix + "/storage/get.yml");
+        InputStream getScheme = storageInterface.get(tenantId, new URI("kestra:///" + prefix + "/storage/get.yml"));
+        assertThat(CharStreams.toString(new InputStreamReader(getScheme)), is(contentString));
+    }
+
+    private void get(String tenantId, String prefix) throws Exception {
+        putFile(tenantId, "/" + prefix + "/storage/get.yml");
+        putFile(tenantId, "/" + prefix + "/storage/level2/2.yml");
+
+        URI item = new URI("/" + prefix + "/storage/get.yml");
+        InputStream get = storageInterface.get(tenantId, item);
+        assertThat(CharStreams.toString(new InputStreamReader(get)), is(contentString));
+        assertTrue(storageInterface.exists(tenantId, item));
+    }
+
+    @Test
+    void getNoTraversal() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+
+        putFile(tenantId, "/" + prefix + "/storage/get.yml");
+        putFile(tenantId, "/" + prefix + "/storage/level2/2.yml");
+        // Assert that '..' in path cannot be used as gcs do not use directory listing and traversal.
+        assertThrows(IllegalArgumentException.class, () -> {
+            storageInterface.get(tenantId, new URI("kestra:///" + prefix + "/storage/level2/../get.yml"));
+        });
+    }
+
+    @Test
+    void getFileNotFound() {
         String prefix = IdUtils.create();
         String tenantId = IdUtils.create();
 
@@ -78,39 +110,720 @@ class AzureStorageTest {
             storageInterface.get(tenantId, new URI("/" + prefix + "/storage/missing.yml"));
         });
     }
+    //endregion
 
+    //region test LIST
+    @Test
+    void list() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        list(prefix, tenantId);
+    }
+
+    @Test
+    void listNoTenant() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = null;
+
+        list(prefix, tenantId);
+    }
+
+    @Test
+    void listNoTraversal() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        List<String> path = Arrays.asList(
+            "/" + prefix + "/storage/root.yml",
+            "/" + prefix + "/storage/level1/1.yml",
+            "/" + prefix + "/storage/level1/level2/1.yml",
+            "/" + prefix + "/storage/another/1.yml"
+        );
+        path.forEach(throwConsumer(s -> putFile(tenantId, s)));
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            storageInterface.list(tenantId, new URI("/" + prefix + "/storage/level2/.."));
+        });
+    }
+
+
+    @Test
+    void listNotFound() {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+        assertThrows(FileNotFoundException.class, () -> {
+            storageInterface.list(tenantId, new URI("/" + prefix + "/storage/"));
+        });
+    }
+
+    @Test
+    void listNoCrossTenant() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        List<String> withTenant = Arrays.asList(
+            "/" + prefix + "/with/1.yml",
+            "/" + prefix + "/with/2.yml",
+            "/" + prefix + "/with/3.yml"
+        );
+        withTenant.forEach(throwConsumer(s -> putFile(tenantId, s)));
+        List<String> nullTenant = Arrays.asList(
+            "/" + prefix + "/notenant/1.yml",
+            "/" + prefix + "/notenant/2.yml",
+            "/" + prefix + "/notenant/3.yml"
+        );
+        nullTenant.forEach(throwConsumer(s -> putFile(null, s)));
+
+        List<FileAttributes> with = storageInterface.list(tenantId, new URI("/" + prefix + "/with"));
+        assertThat(with.stream().map(FileAttributes::getFileName).toList(), containsInAnyOrder("1.yml", "2.yml", "3.yml"));
+        assertThrows(FileNotFoundException.class, () -> {
+            storageInterface.list(tenantId, new URI("/" + prefix + "/notenant/"));
+        });
+
+        List<FileAttributes> notenant = storageInterface.list(null, new URI("/" + prefix + "/notenant"));
+        assertThat(notenant.stream().map(FileAttributes::getFileName).toList(), containsInAnyOrder("1.yml", "2.yml", "3.yml"));
+        assertThrows(FileNotFoundException.class, () -> {
+            storageInterface.list(null, new URI("/" + prefix + "/with/"));
+        });
+    }
+
+    @Test
+    void listWithScheme() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+        List<String> path = Arrays.asList(
+            "/" + prefix + "/storage/root.yml",
+            "/" + prefix + "/storage/level1/1.yml",
+            "/" + prefix + "/storage/level1/level2/1.yml",
+            "/" + prefix + "/storage/another/1.yml"
+        );
+        path.forEach(throwConsumer(s -> putFile(tenantId, s)));
+
+        List<FileAttributes> list = storageInterface.list(tenantId, new URI("kestra:///" + prefix + "/storage"));
+
+        assertThat(list.stream().map(FileAttributes::getFileName).toList(), containsInAnyOrder("root.yml", "level1", "another"));
+    }
+
+    private void list(String prefix, String tenantId) throws Exception {
+        List<String> path = Arrays.asList(
+            "/" + prefix + "/storage/root.yml",
+            "/" + prefix + "/storage/level1/1.yml",
+            "/" + prefix + "/storage/level1/level2/1.yml",
+            "/" + prefix + "/storage/another/1.yml"
+        );
+        path.forEach(throwConsumer(s -> putFile(tenantId, s)));
+
+        List<FileAttributes> list = storageInterface.list(tenantId, new URI("/" + prefix + "/storage"));
+
+        assertThat(list.stream().map(FileAttributes::getFileName).toList(), containsInAnyOrder("root.yml", "level1", "another"));
+    }
+    //endregion
+
+    //region test EXISTS
+    @Test
+    void exists() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = null;
+
+        exists(prefix, tenantId);
+    }
+
+    @Test
+    void existsNoTenant() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = null;
+
+        exists(prefix, tenantId);
+    }
+
+    private void exists(String prefix, String tenantId) throws Exception {
+        URI put = putFile(tenantId, "/" + prefix + "/storage/put.yml");
+        assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/put.yml")), is(true));
+        assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/notfound.yml")), is(false));
+    }
+
+    @Test
+    void existsNoTraversal() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        List<String> path = Arrays.asList(
+            "/" + prefix + "/storage/root.yml",
+            "/" + prefix + "/storage/level1/1.yml",
+            "/" + prefix + "/storage/level1/level2/1.yml",
+            "/" + prefix + "/storage/another/1.yml"
+        );
+        path.forEach(throwConsumer(s -> putFile(tenantId, s)));
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/level2/.."));
+        });
+    }
+
+    @Test
+    void existsNoCrossTenant() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        String withTenant = "/" + prefix + "/storage/withtenant.yml";
+        putFile(tenantId, withTenant);
+        String nullTenant = "/" + prefix + "/storage/nulltenant.yml";
+        putFile(null, nullTenant);
+
+        URI with = new URI(withTenant);
+        assertTrue(storageInterface.exists(tenantId, with));
+        assertFalse(storageInterface.exists(nullTenant, with));
+
+        URI without = new URI(nullTenant);
+        assertTrue(storageInterface.exists(null, without));
+        assertFalse(storageInterface.exists(tenantId, without));
+
+    }
+
+    @Test
+    void existsWithScheme() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        putFile(tenantId, "/" + prefix + "/storage/get.yml");
+        assertTrue(storageInterface.exists(tenantId, new URI("kestra:///" + prefix + "/storage/get.yml")));
+    }
+    //endregion
+
+    //region test SIZE
+    @Test
+    void size() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = null;
+
+        size(prefix, tenantId);
+    }
+
+    @Test
+    void sizeNoTenant() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = null;
+
+        size(prefix, tenantId);
+    }
+
+    private void size(String prefix, String tenantId) throws Exception {
+        URI put = putFile(tenantId, "/" + prefix + "/storage/put.yml");
+        assertThat(storageInterface.size(tenantId, new URI("/" + prefix + "/storage/put.yml")), is((long) contentString.length()));
+    }
+
+    @Test
+    void sizeNoTraversal() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        List<String> path = Arrays.asList(
+            "/" + prefix + "/storage/root.yml",
+            "/" + prefix + "/storage/level1/1.yml",
+            "/" + prefix + "/storage/level1/level2/1.yml"
+        );
+        path.forEach(throwConsumer(s -> putFile(tenantId, s)));
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            storageInterface.size(tenantId, new URI("/" + prefix + "/storage/level2/../1.yml"));
+        });
+    }
+
+    @Test
+    void sizeNotFound() {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+        assertThrows(FileNotFoundException.class, () -> {
+            storageInterface.size(tenantId, new URI("/" + prefix + "/storage/"));
+        });
+    }
+
+    @Test
+    void sizeNoCrossTenant() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        String withTenant = "/" + prefix + "/storage/withtenant.yml";
+        putFile(tenantId, withTenant);
+        String nullTenant = "/" + prefix + "/storage/nulltenant.yml";
+        putFile(null, nullTenant);
+
+        URI with = new URI(withTenant);
+        assertThat(storageInterface.size(tenantId, with), is((long) contentString.length()));
+        assertThrows(FileNotFoundException.class, () -> {
+            storageInterface.size(null, with);
+        });
+
+        URI without = new URI(nullTenant);
+        assertThat(storageInterface.size(null, without), is((long) contentString.length()));
+        assertThrows(FileNotFoundException.class, () -> {
+            storageInterface.size(tenantId, without);
+        });
+
+    }
+
+    @Test
+    void sizeWithScheme() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        putFile(tenantId, "/" + prefix + "/storage/get.yml");
+        assertThat(storageInterface.size(tenantId, new URI("kestra:///" + prefix + "/storage/get.yml")), is((long) contentString.length()));
+    }
+    //endregion
+
+    //region test LASTMODIFIEDTIME
+    @Test
+    void lastModifiedTime() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = null;
+
+        lastModifiedTime(prefix, tenantId);
+    }
+
+    @Test
+    void lastModifiedTimeNoTenant() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = null;
+
+        lastModifiedTime(prefix, tenantId);
+    }
+
+    private void lastModifiedTime(String prefix, String tenantId) throws Exception {
+        URI put = putFile(tenantId, "/" + prefix + "/storage/put.yml");
+        assertThat(storageInterface.lastModifiedTime(tenantId, new URI("/" + prefix + "/storage/put.yml")), notNullValue());
+    }
+
+    @Test
+    void lastModifiedTimeNoTraversal() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        List<String> path = Arrays.asList(
+            "/" + prefix + "/storage/root.yml",
+            "/" + prefix + "/storage/level1/1.yml",
+            "/" + prefix + "/storage/level1/level2/1.yml"
+        );
+        path.forEach(throwConsumer(s -> putFile(tenantId, s)));
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            storageInterface.lastModifiedTime(tenantId, new URI("/" + prefix + "/storage/level2/../1.yml"));
+        });
+    }
+
+    @Test
+    void lastModifiedTimeNotFound() {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+        assertThrows(FileNotFoundException.class, () -> {
+            storageInterface.lastModifiedTime(tenantId, new URI("/" + prefix + "/storage/"));
+        });
+    }
+
+    @Test
+    void lastModifiedTimeNoCrossTenant() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        String withTenant = "/" + prefix + "/storage/withtenant.yml";
+        putFile(tenantId, withTenant);
+        String nullTenant = "/" + prefix + "/storage/nulltenant.yml";
+        putFile(null, nullTenant);
+
+        URI with = new URI(withTenant);
+        assertThat(storageInterface.lastModifiedTime(tenantId, with), notNullValue());
+        assertThrows(FileNotFoundException.class, () -> {
+            storageInterface.lastModifiedTime(null, with);
+        });
+
+        URI without = new URI(nullTenant);
+        assertThat(storageInterface.lastModifiedTime(null, without), notNullValue());
+        assertThrows(FileNotFoundException.class, () -> {
+            storageInterface.lastModifiedTime(tenantId, without);
+        });
+
+    }
+
+    @Test
+    void lastModifiedTimeWithScheme() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        putFile(tenantId, "/" + prefix + "/storage/get.yml");
+        assertThat(storageInterface.lastModifiedTime(tenantId, new URI("kestra:///" + prefix + "/storage/get.yml")), notNullValue());
+    }
+    //endregion
+
+    //region test GETATTRIBUTES
+    @Test
+    void getAttributes() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        getAttributes(prefix, tenantId);
+    }
+
+    @Test
+    void getAttributesNoTenant() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = null;
+
+        getAttributes(prefix, tenantId);
+    }
+
+    private void getAttributes(String prefix, String tenantId) throws Exception {
+        List<String> path = Arrays.asList(
+            "/" + prefix + "/storage/root.yml",
+            "/" + prefix + "/storage/level1/1.yml"
+        );
+        path.forEach(throwConsumer(s -> this.putFile(tenantId, s)));
+
+        FileAttributes attr = storageInterface.getAttributes(tenantId, new URI("/" + prefix + "/storage/root.yml"));
+        assertThat(attr.getFileName(), is("root.yml"));
+        assertThat(attr.getType(), is(FileAttributes.FileType.File));
+        assertThat(attr.getSize(), is((long) contentString.length()));
+        assertThat(attr.getLastModifiedTime(), notNullValue());
+        assertThat(attr.getCreationTime(), notNullValue());
+
+        attr = storageInterface.getAttributes(tenantId, new URI("/" + prefix + "/storage/level1"));
+        assertThat(attr.getFileName(), is("level1"));
+        assertThat(attr.getType(), is(FileAttributes.FileType.Directory));
+        assertThat(attr.getLastModifiedTime(), notNullValue());
+        assertThat(attr.getCreationTime(), notNullValue());
+    }
+
+    @Test
+    void getAttributesNoTraversal() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        List<String> path = Arrays.asList(
+            "/" + prefix + "/storage/root.yml",
+            "/" + prefix + "/storage/level1/1.yml",
+            "/" + prefix + "/storage/level1/level2/1.yml"
+        );
+        path.forEach(throwConsumer(s -> putFile(tenantId, s)));
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            storageInterface.getAttributes(tenantId, new URI("/" + prefix + "/storage/level2/../1.yml"));
+        });
+    }
+
+    @Test
+    void getAttributesNotFound() {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+        assertThrows(FileNotFoundException.class, () -> {
+            storageInterface.getAttributes(tenantId, new URI("/" + prefix + "/storage/"));
+        });
+    }
+
+    @Test
+    void getAttributesNoCrossTenant() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        String withTenant = "/" + prefix + "/storage/withtenant.yml";
+        putFile(tenantId, withTenant);
+        String nullTenant = "/" + prefix + "/storage/nulltenant.yml";
+        putFile(null, nullTenant);
+
+        URI with = new URI(withTenant);
+        FileAttributes attr = storageInterface.getAttributes(tenantId, with);
+        assertThat(attr.getFileName(), is("withtenant.yml"));
+        assertThrows(FileNotFoundException.class, () -> {
+            storageInterface.getAttributes(null, with);
+        });
+
+        URI without = new URI(nullTenant);
+        attr = storageInterface.getAttributes(null, without);
+        assertThat(attr.getFileName(), is("nulltenant.yml"));
+        assertThrows(FileNotFoundException.class, () -> {
+            storageInterface.getAttributes(tenantId, without);
+        });
+    }
+
+    @Test
+    void getAttributesWithScheme() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        putFile(tenantId, "/" + prefix + "/storage/get.yml");
+        FileAttributes attr = storageInterface.getAttributes(tenantId, new URI("kestra:///" + prefix + "/storage/get.yml"));
+        assertThat(attr.getFileName(), is("get.yml"));
+    }
+    //endregion
+
+    //region test PUT
     @Test
     void put() throws Exception {
         String prefix = IdUtils.create();
         String tenantId = IdUtils.create();
 
-        URL resource = AzureStorageTest.class.getClassLoader().getResource("application.yml");
-        URI put = this.putFile(tenantId, resource, "/" + prefix + "/storage/put.yml");
+        put(tenantId, prefix);
+    }
+
+    @Test
+    void putNoTenant() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = null;
+
+        put(tenantId, prefix);
+    }
+
+    @Test
+    void putWithScheme() throws URISyntaxException, IOException {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        URI uri = new URI("kestra:///" + prefix + "/storage/get.yml");
+        storageInterface.put(
+            tenantId,
+            uri,
+            new ByteArrayInputStream(contentString.getBytes())
+        );
+        InputStream getScheme = storageInterface.get(tenantId, new URI("/" + prefix + "/storage/get.yml"));
+        assertThat(CharStreams.toString(new InputStreamReader(getScheme)), is(contentString));
+    }
+
+    @Test
+    void putNoTraversal() throws URISyntaxException, IOException {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        storageInterface.createDirectory(tenantId, new URI("/" + prefix + "/storage/level1"));
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            storageInterface.put(
+                tenantId,
+                new URI("kestra:///" + prefix + "/storage/level1/../get2.yml"),
+                new ByteArrayInputStream(contentString.getBytes())
+            );
+        });
+
+    }
+
+    private void put(String tenantId, String prefix) throws Exception {
+        URI put = putFile(tenantId, "/" + prefix + "/storage/put.yml");
         InputStream get = storageInterface.get(tenantId, new URI("/" + prefix + "/storage/put.yml"));
 
         assertThat(put.toString(), is(new URI("kestra:///" + prefix + "/storage/put.yml").toString()));
         assertThat(
             CharStreams.toString(new InputStreamReader(get)),
-            is(CharStreams.toString(new InputStreamReader(new FileInputStream(Objects.requireNonNull(resource).getFile()))))
+            is(contentString)
         );
+    }
+    //endregion
 
-        assertThat(storageInterface.size(tenantId, new URI("/" + prefix + "/storage/put.yml")), is(130L));
+    //region test DELETE
+    @Test
+    void delete() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
 
-        assertThrows(FileNotFoundException.class, () -> {
-            assertThat(storageInterface.size(tenantId, new URI("/" + prefix + "/storage/muissing.yml")), is(76L));
-        });
+        delete(prefix, tenantId);
+    }
 
-        boolean delete = storageInterface.delete(tenantId, put);
-        assertThat(delete, is(true));
+    @Test
+    void deleteNoTenant() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = null;
 
-        delete = storageInterface.delete(tenantId, put);
-        assertThat(delete, is(false));
+        delete(prefix, tenantId);
+    }
 
-        assertThrows(FileNotFoundException.class, () -> {
-            storageInterface.get(tenantId, new URI("/" + prefix + "/storage/put.yml"));
+    @Test
+    void deleteNoTraversal() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+        List<String> path = Arrays.asList(
+            "/" + prefix + "/storage/root.yml",
+            "/" + prefix + "/storage/level1/1.yml",
+            "/" + prefix + "/storage/level1/level2/1.yml",
+            "/" + prefix + "/storage/another/1.yml"
+        );
+        path.forEach(throwConsumer(s -> this.putFile(tenantId, s)));
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            storageInterface.delete(tenantId, new URI("/" + prefix + "/storage/level2/../1.yml"));
         });
     }
 
+    @Test
+    void deleteNotFound() throws URISyntaxException, IOException {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+        assertThat(storageInterface.delete(tenantId, new URI("/" + prefix + "/storage/")), is(false));
+    }
+
+    private void delete(String prefix, String tenantId) throws Exception {
+        List<String> path = Arrays.asList(
+            "/" + prefix + "/storage/root.yml",
+            "/" + prefix + "/storage/level1/1.yml",
+            "/" + prefix + "/storage/level1/level2/1.yml",
+            "/" + prefix + "/storage/another/1.yml"
+        );
+        path.forEach(throwConsumer(s -> this.putFile(tenantId, s)));
+
+        boolean deleted = storageInterface.delete(tenantId, new URI("/" + prefix + "/storage/level1"));
+        assertThat(deleted, is(true));
+        assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/root.yml")), is(true));
+        assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/another/1.yml")), is(true));
+        assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/level1")), is(false));
+        assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/level1/1.yml")), is(false));
+        assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/level1/level2/1.yml")), is(false));
+        deleted = storageInterface.delete(tenantId, new URI("/" + prefix + "/storage/root.yml"));
+        assertThat(deleted, is(true));
+        assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/root.yml")), is(false));
+    }
+
+    @Test
+    void deleteWithScheme() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        putFile(tenantId, "/" + prefix + "/storage/get.yml");
+        assertTrue(storageInterface.delete(tenantId, new URI("kestra:///" + prefix + "/storage/get.yml")));
+        assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/get.yml")), is(false));
+    }
+    //endregion
+
+    //region test CREATEDIRECTORY
+    @Test
+    void createDirectory() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = null;
+
+        createDirectory(prefix, tenantId);
+    }
+
+    @Test
+    void createDirectoryNoTenant() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = null;
+
+        createDirectory(prefix, tenantId);
+    }
+
+    @Test
+    void createDirectoryNoTraversal() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+        List<String> path = Arrays.asList(
+            "/" + prefix + "/storage/root.yml",
+            "/" + prefix + "/storage/level1/1.yml",
+            "/" + prefix + "/storage/level1/level2/1.yml",
+            "/" + prefix + "/storage/another/1.yml"
+        );
+        path.forEach(throwConsumer(s -> this.putFile(tenantId, s)));
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            storageInterface.createDirectory(tenantId, new URI("/" + prefix + "/storage/level2/../newdir"));
+        });
+    }
+
+    private void createDirectory(String prefix, String tenantId) throws Exception {
+        storageInterface.createDirectory(tenantId, new URI("/" + prefix + "/storage/level1"));
+        FileAttributes attr = storageInterface.getAttributes(tenantId, new URI("/" + prefix + "/storage/level1"));
+        assertThat(attr.getFileName(), is("level1"));
+        assertThat(attr.getType(), is(FileAttributes.FileType.Directory));
+        assertThat(attr.getLastModifiedTime(), notNullValue());
+    }
+
+    @Test
+    void createDirectoryWithScheme() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        storageInterface.createDirectory(tenantId, new URI("kestra:///" + prefix + "/storage/level1"));
+        FileAttributes attr = storageInterface.getAttributes(tenantId, new URI("/" + prefix + "/storage/level1"));
+        assertThat(attr.getFileName(), is("level1"));
+        assertThat(attr.getType(), is(FileAttributes.FileType.Directory));
+        assertThat(attr.getLastModifiedTime(), notNullValue());
+    }
+    //endregion
+
+    //region test MOVE
+    @Test
+    void move() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = null;
+
+        move(prefix, tenantId);
+    }
+
+    @Test
+    void moveNoTenant() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = null;
+
+        move(prefix, tenantId);
+    }
+
+    @Test
+    void moveNotFound() {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+        assertThrows(FileNotFoundException.class, () -> {
+            storageInterface.move(tenantId, new URI("/" + prefix + "/storage/"), new URI("/" + prefix + "/test/"));
+        });
+    }
+
+    @Test
+    void moveNoTraversal() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+        List<String> path = Arrays.asList(
+            "/" + prefix + "/storage/root.yml",
+            "/" + prefix + "/storage/level1/1.yml",
+            "/" + prefix + "/storage/level1/level2/1.yml",
+            "/" + prefix + "/storage/another/1.yml"
+        );
+        path.forEach(throwConsumer(s -> this.putFile(tenantId, s)));
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            storageInterface.move(tenantId, new URI("/" + prefix + "/storage/level2/../1.yml"), new URI("/" + prefix + "/storage/level2/1.yml"));
+        });
+    }
+
+    private void move(String prefix, String tenantId) throws Exception {
+        List<String> path = Arrays.asList(
+            "/" + prefix + "/storage/root.yml",
+            "/" + prefix + "/storage/level1/1.yml",
+            "/" + prefix + "/storage/level1/level2/2.yml",
+            "/" + prefix + "/storage/another/1.yml"
+        );
+        path.forEach(throwConsumer(s -> this.putFile(tenantId, s)));
+
+        storageInterface.move(tenantId, new URI("/" + prefix + "/storage/level1"), new URI("/" + prefix + "/storage/moved"));
+
+        List<FileAttributes> list = storageInterface.list(tenantId, new URI("/" + prefix + "/storage/moved"));
+        assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/level1")), is(false));
+        assertThat(list.stream().map(FileAttributes::getFileName).toList(), containsInAnyOrder("level2", "1.yml"));
+
+        list = storageInterface.list(tenantId, new URI("/" + prefix + "/storage/moved/level2"));
+        assertThat(list.stream().map(FileAttributes::getFileName).toList(), containsInAnyOrder("2.yml"));
+
+        storageInterface.move(tenantId, new URI("/" + prefix + "/storage/root.yml"), new URI("/" + prefix + "/storage/root-moved.yml"));
+        assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/root.yml")), is(false));
+        assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/root-moved.yml")), is(true));
+    }
+
+    @Test
+    void moveWithScheme() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        this.putFile(tenantId, "/" + prefix + "/storage/root.yml");
+
+        storageInterface.move(tenantId, new URI("kestra:///" + prefix + "/storage/root.yml"), new URI("kestra:///" + prefix + "/storage/root-moved.yml"));
+        assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/root.yml")), is(false));
+        assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/root-moved.yml")), is(true));
+    }
+    //endregion
+
+    //region test DELETEBYPREFIX
     @Test
     void deleteByPrefix() throws Exception {
         String prefix = IdUtils.create();
@@ -127,8 +840,65 @@ class AzureStorageTest {
         deleteByPrefix(prefix, tenantId);
     }
 
+    @Test
+    void deleteByPrefixNotFound() throws URISyntaxException, IOException {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+        assertThat(storageInterface.deleteByPrefix(tenantId, new URI("/" + prefix + "/storage/")), containsInAnyOrder());
+    }
+
+    @Test
+    void deleteByPrefixNoTraversal() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+        List<String> path = Arrays.asList(
+            "/" + prefix + "/storage/root.yml",
+            "/" + prefix + "/storage/level1/1.yml",
+            "/" + prefix + "/storage/level1/level2/1.yml",
+            "/" + prefix + "/storage/another/1.yml"
+        );
+        path.forEach(throwConsumer(s -> this.putFile(tenantId, s)));
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            storageInterface.move(tenantId, new URI("/" + prefix + "/storage/level2/../1.yml"), new URI("/" + prefix + "/storage/level2/1.yml"));
+        });
+    }
+
     private void deleteByPrefix(String prefix, String tenantId) throws Exception {
-        URL resource = AzureStorageTest.class.getClassLoader().getResource("application.yml");
+        List<String> path = Arrays.asList(
+            "/" + prefix + "/storage/root.yml",
+            "/" + prefix + "/storage/level1/1.yml",
+            "/" + prefix + "/storage/level1/level2/1.yml"
+        );
+
+        path.forEach(throwConsumer(s -> this.putFile(tenantId, s)));
+
+        List<URI> deleted = storageInterface.deleteByPrefix(tenantId, new URI("/" + prefix + "/storage/"));
+
+        List<String> res = Arrays.asList(
+            "/" + prefix + "/storage",
+            "/" + prefix + "/storage/root.yml",
+            "/" + prefix + "/storage/level1",
+            "/" + prefix + "/storage/level1/1.yml",
+            "/" + prefix + "/storage/level1/level2",
+            "/" + prefix + "/storage/level1/level2/1.yml"
+        );
+
+        assertThat(deleted, containsInAnyOrder(res.stream().map(s -> URI.create("kestra://" + s)).toArray()));
+
+        assertThrows(FileNotFoundException.class, () -> {
+            storageInterface.get(tenantId, new URI("/" + prefix + "/storage/"));
+        });
+
+        path.forEach(throwConsumer(s -> {
+            assertThat(storageInterface.exists(tenantId, new URI(s)), is(false));
+        }));
+    }
+
+    @Test
+    void deleteByPrefixWithScheme() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
 
         List<String> path = Arrays.asList(
             "/" + prefix + "/storage/root.yml",
@@ -136,26 +906,37 @@ class AzureStorageTest {
             "/" + prefix + "/storage/level1/level2/1.yml"
         );
 
-        path.forEach(throwConsumer(s -> this.putFile(tenantId, resource, s)));
+        path.forEach(throwConsumer(s -> this.putFile(tenantId, s)));
 
         List<URI> deleted = storageInterface.deleteByPrefix(tenantId, new URI("/" + prefix + "/storage/"));
 
-        assertThat(deleted, containsInAnyOrder(path.stream().map(s -> URI.create("kestra://" + s)).toArray()));
+        List<String> res = Arrays.asList(
+            "/" + prefix + "/storage",
+            "/" + prefix + "/storage/root.yml",
+            "/" + prefix + "/storage/level1",
+            "/" + prefix + "/storage/level1/1.yml",
+            "/" + prefix + "/storage/level1/level2",
+            "/" + prefix + "/storage/level1/level2/1.yml"
+        );
 
-        path
-            .forEach(s -> {
-                assertThrows(FileNotFoundException.class, () -> {
-                    storageInterface.get(tenantId, new URI(s));
-                });
-            });
+        assertThat(deleted, containsInAnyOrder(res.stream().map(s -> URI.create("kestra://" + s)).toArray()));
+
+        assertThrows(FileNotFoundException.class, () -> {
+            storageInterface.get(tenantId, new URI("kestra:///" + prefix + "/storage/"));
+        });
+
+        path.forEach(throwConsumer(s -> {
+            assertThat(storageInterface.exists(tenantId, new URI(s)), is(false));
+        }));
     }
 
-    @Test
-    void deleteByPrefixNoResult() throws Exception {
-        String prefix = IdUtils.create();
-        String tenantId = IdUtils.create();
+    //endregion
 
-        List<URI> deleted = storageInterface.deleteByPrefix(tenantId, new URI("/" + prefix + "/storage/"));
-        assertThat(deleted.size(), is(0));
+    private URI putFile(String tenantId, String path) throws Exception {
+        return storageInterface.put(
+            tenantId,
+            new URI(path),
+            new ByteArrayInputStream(contentString.getBytes())
+        );
     }
 }


### PR DESCRIPTION
Implement new interface for multifile editor

To test this you need an azure storage account.

```
kestra:
  storage:
    type: azure
    azure:
      endpoint: "https://unittestkt.blob.core.windows.net"
      container: storage
      connection-string: "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<>;AccountKey=<>"```