### PR TITLE
fix: last modified time & creation time as millis instead of seconds

### DIFF
--- a/src/main/java/io/kestra/storage/azure/AzureFileAttributes.java
+++ b/src/main/java/io/kestra/storage/azure/AzureFileAttributes.java
@@ -17,12 +17,12 @@ public class AzureFileAttributes implements FileAttributes {
 
     @Override
     public long getLastModifiedTime() {
-        return properties.getLastModified().toEpochSecond();
+        return properties.getLastModified().toInstant().toEpochMilli();
     }
 
     @Override
     public long getCreationTime() {
-        return properties.getCreationTime().toEpochSecond();
+        return properties.getCreationTime().toInstant().toEpochMilli();
     }
 
     @Override


### PR DESCRIPTION
part of kestra-io/kestra#4705