### PR TITLE
feat(storage): override purgeByLastModified with native flat listing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,4 +46,5 @@ jobs:
     with:
       skip-test: ${{ github.event.inputs.skip-test == 'true' }}
       kestra-version: ${{ github.event.inputs.kestra-version }}
+      java-version: '25'
     secrets: inherit

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
     }
 }
 
-final targetJavaVersion = JavaVersion.VERSION_21
+final targetJavaVersion = JavaVersion.VERSION_25
 
 java {
     sourceCompatibility = targetJavaVersion
@@ -116,7 +116,7 @@ dependencies {
  **********************************************************************************************************************/
 dependencies {
     testImplementation enforcedPlatform("io.kestra:platform:$kestraVersion")
-    testImplementation "io.qameta.allure:allure-junit5"
+    testImplementation "io.qameta.allure:allure-junit5:2.34.0"
 }
 
 configurations {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.2.4-SNAPSHOT
-kestraVersion=1.0.0
+kestraVersion=2.0.0-SNAPSHOT

--- a/src/main/java/io/kestra/storage/azure/AzureStorage.java
+++ b/src/main/java/io/kestra/storage/azure/AzureStorage.java
@@ -4,11 +4,13 @@ import java.io.*;
 import java.net.URI;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.Strings;
@@ -436,6 +438,103 @@ public class AzureStorage implements AzureConfig, StorageInterface {
         } catch (BlobStorageException e) {
             if (e.getErrorCode() == BlobErrorCode.BLOB_NOT_FOUND || e.getErrorCode() == BlobErrorCode.RESOURCE_NOT_FOUND) {
                 return List.of();
+            }
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public List<URI> purgeByLastModified(
+        String tenantId,
+        @Nullable String namespace,
+        URI prefix,
+        @Nullable Instant startDate,
+        @Nullable Instant endDate,
+        boolean dryRun) throws IOException {
+        String resolvedPath = getPath(tenantId, prefix);
+        if (!resolvedPath.endsWith("/")) {
+            resolvedPath += "/";
+        }
+        final String blobPrefix = resolvedPath;
+        String prefixPath = prefix.getPath();
+
+        ListBlobsOptions options = new ListBlobsOptions()
+            .setPrefix(blobPrefix)
+            .setDetails(new BlobListDetails().setRetrieveDeletedBlobs(false).setRetrieveSnapshots(false));
+
+        List<URI> matched = new ArrayList<>();
+        try {
+            for (BlobItem item : this.blobContainerClient.listBlobs(options, null)) {
+                String name = item.getName();
+                // skip directory markers — purge targets files only
+                if (name.endsWith("/" + DIRECTORY_MARKER_FILE) || name.endsWith(DIRECTORY_MARKER_FILE)) {
+                    continue;
+                }
+                if (isInWindow(item, startDate, endDate)) {
+                    matched.add(URI.create("kestra://" + prefixPath + name.substring(blobPrefix.length())));
+                }
+            }
+        } catch (BlobStorageException e) {
+            if (e.getErrorCode() == BlobErrorCode.BLOB_NOT_FOUND || e.getErrorCode() == BlobErrorCode.RESOURCE_NOT_FOUND) {
+                return List.of();
+            }
+            throw new IOException(e);
+        }
+
+        if (dryRun || matched.isEmpty()) {
+            return matched;
+        }
+
+        var pool = Executors.newFixedThreadPool(16);
+        try {
+            List<Future<Void>> futures = matched.stream()
+                .<Future<Void>> map(uri -> pool.submit(() ->
+                {
+                    deleteBlobByStoragePath(uri, prefixPath, blobPrefix);
+                    return null;
+                }))
+                .toList();
+            for (Future<Void> future : futures) {
+                try {
+                    future.get();
+                } catch (java.util.concurrent.ExecutionException e) {
+                    var cause = e.getCause();
+                    if (cause instanceof IOException ioe) {
+                        throw ioe;
+                    }
+                    throw new IOException("Failed to delete blob during purge", cause);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Purge interrupted", e);
+                }
+            }
+        } finally {
+            pool.shutdown();
+        }
+
+        return matched;
+    }
+
+    private boolean isInWindow(BlobItem item, @Nullable Instant startDate, @Nullable Instant endDate) {
+        var lastModified = item.getProperties().getLastModified();
+        if (lastModified == null) {
+            return false;
+        }
+        var ts = lastModified.toInstant();
+        return (startDate == null || !ts.isBefore(startDate))
+            && (endDate == null || !ts.isAfter(endDate));
+    }
+
+    private void deleteBlobByStoragePath(URI kestraUri, String prefixPath, String blobPrefix) throws IOException {
+        // reconstruct blob name: blobPrefix + suffix part of the kestra URI
+        String suffix = kestraUri.getPath().substring(prefixPath.length());
+        String blobName = blobPrefix + suffix;
+        try {
+            this.blobContainerClient.getBlobClient(blobName).delete();
+        } catch (BlobStorageException e) {
+            // already gone — treat as success
+            if (e.getErrorCode() == BlobErrorCode.BLOB_NOT_FOUND || e.getErrorCode() == BlobErrorCode.RESOURCE_NOT_FOUND) {
+                return;
             }
             throw new IOException(e);
         }

--- a/src/main/java/io/kestra/storage/azure/AzureStorage.java
+++ b/src/main/java/io/kestra/storage/azure/AzureStorage.java
@@ -456,7 +456,7 @@ public class AzureStorage implements AzureConfig, StorageInterface {
             resolvedPath += "/";
         }
         final String blobPrefix = resolvedPath;
-        String prefixPath = prefix.getPath();
+        String prefixPath = prefix.getPath().endsWith("/") ? prefix.getPath() : prefix.getPath() + "/";
 
         ListBlobsOptions options = new ListBlobsOptions()
             .setPrefix(blobPrefix)
@@ -467,7 +467,7 @@ public class AzureStorage implements AzureConfig, StorageInterface {
             for (BlobItem item : this.blobContainerClient.listBlobs(options, null)) {
                 String name = item.getName();
                 // skip directory markers — purge targets files only
-                if (name.endsWith("/" + DIRECTORY_MARKER_FILE) || name.endsWith(DIRECTORY_MARKER_FILE)) {
+                if (name.endsWith(DIRECTORY_MARKER_FILE)) {
                     continue;
                 }
                 if (isInWindow(item, startDate, endDate)) {

--- a/src/test/java/io/kestra/storage/azure/AzureStoragePurgeTest.java
+++ b/src/test/java/io/kestra/storage/azure/AzureStoragePurgeTest.java
@@ -1,0 +1,158 @@
+package io.kestra.storage.azure;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.utils.IdUtils;
+
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+@KestraTest(environments = "secrets")
+class AzureStoragePurgeTest {
+
+    private static final String TENANT = "tenant-" + IdUtils.create();
+
+    @Inject
+    private StorageInterface storageInterface;
+
+    private URI upload(String prefix, String filename) throws Exception {
+        var uri = URI.create("/" + prefix + "/" + filename);
+        storageInterface.put(TENANT, null, uri, new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8)));
+        return URI.create("kestra://" + uri.getPath());
+    }
+
+    @Test
+    void inWindowFilesAreDeletedAndReturned() throws Exception {
+        var prefix = IdUtils.create();
+        var before = Instant.now().minusSeconds(5);
+        var file1 = upload(prefix, "a.txt");
+        var file2 = upload(prefix, "b.txt");
+        var after = Instant.now().plusSeconds(5);
+
+        var result = storageInterface.purgeByLastModified(
+            TENANT, null, URI.create("/" + prefix + "/"), before, after, false
+        );
+
+        assertThat(result, hasSize(2));
+        assertThat(result, containsInAnyOrder(file1, file2));
+        // files must be gone
+        assertThat(storageInterface.exists(TENANT, null, file1), is(false));
+        assertThat(storageInterface.exists(TENANT, null, file2), is(false));
+    }
+
+    @Test
+    void outOfWindowFilesArePreserved() throws Exception {
+        var prefix = IdUtils.create();
+        upload(prefix, "old.txt");
+
+        // window is in the future — nothing matches
+        var future = Instant.now().plusSeconds(60);
+        var result = storageInterface.purgeByLastModified(
+            TENANT, null, URI.create("/" + prefix + "/"), future, null, false
+        );
+
+        assertThat(result, is(empty()));
+        // the file must still exist
+        assertThat(storageInterface.exists(TENANT, null, URI.create("kestra:///" + prefix + "/old.txt")), is(true));
+    }
+
+    @Test
+    void dryRunReturnMatchesWithoutDeleting() throws Exception {
+        var prefix = IdUtils.create();
+        var file = upload(prefix, "c.txt");
+        var before = Instant.now().minusSeconds(5);
+        var after = Instant.now().plusSeconds(5);
+
+        var result = storageInterface.purgeByLastModified(
+            TENANT, null, URI.create("/" + prefix + "/"), before, after, true
+        );
+
+        assertThat(result, hasSize(1));
+        assertThat(result, containsInAnyOrder(file));
+        // file must still be present after dry-run
+        assertThat(storageInterface.exists(TENANT, null, file), is(true));
+    }
+
+    @Test
+    void missingPrefixReturnsEmptyList() throws Exception {
+        var nonexistent = "nonexistent-" + IdUtils.create();
+
+        var result = storageInterface.purgeByLastModified(
+            TENANT, null, URI.create("/" + nonexistent + "/"), null, null, false
+        );
+
+        assertThat(result, is(empty()));
+    }
+
+    @Test
+    void nullStartBoundMatchesAllBeforeEnd() throws Exception {
+        var prefix = IdUtils.create();
+        var file = upload(prefix, "d.txt");
+        var after = Instant.now().plusSeconds(5);
+
+        var result = storageInterface.purgeByLastModified(
+            TENANT, null, URI.create("/" + prefix + "/"), null, after, false
+        );
+
+        assertThat(result, hasSize(1));
+        assertThat(result, containsInAnyOrder(file));
+    }
+
+    @Test
+    void nullEndBoundMatchesAllAfterStart() throws Exception {
+        var prefix = IdUtils.create();
+        var file = upload(prefix, "e.txt");
+        var before = Instant.now().minusSeconds(5);
+
+        var result = storageInterface.purgeByLastModified(
+            TENANT, null, URI.create("/" + prefix + "/"), before, null, false
+        );
+
+        assertThat(result, hasSize(1));
+        assertThat(result, containsInAnyOrder(file));
+    }
+
+    @Test
+    void bothNullBoundsMatchesAll() throws Exception {
+        var prefix = IdUtils.create();
+        var file1 = upload(prefix, "f.txt");
+        var file2 = upload(prefix, "g.txt");
+
+        var result = storageInterface.purgeByLastModified(
+            TENANT, null, URI.create("/" + prefix + "/"), null, null, false
+        );
+
+        assertThat(result, hasSize(2));
+        assertThat(result, containsInAnyOrder(file1, file2));
+    }
+
+    @Test
+    void siblingPrefixNotAffected() throws Exception {
+        var prefix = IdUtils.create();
+        // upload under prefix/ and prefix-sibling/
+        var fileInPrefix = upload(prefix, "h.txt");
+        var sibling = prefix + "-sibling";
+        var fileInSibling = upload(sibling, "i.txt");
+        var before = Instant.now().minusSeconds(5);
+        var after = Instant.now().plusSeconds(5);
+
+        storageInterface.purgeByLastModified(
+            TENANT, null, URI.create("/" + prefix + "/"), before, after, false
+        );
+
+        // sibling must be unaffected
+        assertThat(storageInterface.exists(TENANT, null, fileInSibling), is(true));
+    }
+}

--- a/src/test/java/io/kestra/storage/azure/MigrationTestFactory.java
+++ b/src/test/java/io/kestra/storage/azure/MigrationTestFactory.java
@@ -1,0 +1,71 @@
+package io.kestra.storage.azure;
+
+import io.kestra.core.migration.MigrationHistoryStore;
+import io.kestra.core.migration.MigrationLock;
+import io.kestra.core.migration.MigrationScript;
+
+import io.micronaut.context.annotation.Factory;
+import jakarta.inject.Singleton;
+
+/**
+ * Provides no-op migration beans for the in-memory test context.
+ * The memory backend ships no MigrationLock / MigrationHistoryStore implementation,
+ * but MigrationRunner (activated by kestra.repository.type=memory) requires them.
+ */
+@Factory
+class MigrationTestFactory {
+
+    @Singleton
+    MigrationLock migrationLock() {
+        return new MigrationLock() {
+            @Override
+            public void acquire() {
+            }
+
+            @Override
+            public void release() {
+            }
+
+            @Override
+            public boolean tryAcquire() {
+                return true;
+            }
+
+            @Override
+            public void forceRelease() {
+            }
+        };
+    }
+
+    @Singleton
+    MigrationHistoryStore migrationHistoryStore() {
+        return new MigrationHistoryStore() {
+            @Override
+            public void bootstrapIfNeeded() {
+            }
+
+            @Override
+            public boolean hasAnyApplied() {
+                return true;
+            }
+
+            @Override
+            public boolean isApplied(String scriptId) {
+                return true;
+            }
+
+            @Override
+            public void validateChecksum(MigrationScript script) {
+            }
+
+            @Override
+            public void markApplied(MigrationScript script, long executionMs) {
+            }
+
+            @Override
+            public boolean detectLegacyUpgrade() {
+                return false;
+            }
+        };
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -8,3 +8,7 @@ kestra:
     azure:
       endpoint: "https://unittestkt.blob.core.windows.net"
       container: storage
+
+grpc:
+  server:
+    enabled: false


### PR DESCRIPTION
## What

Overrides `StorageInterface#purgeByLastModified` in `AzureStorage` with a native implementation:

- **Single flat paginated listing** via `BlobContainerClient.listBlobs(prefix)` — no per-directory recursion; last-modified comes from the listing itself (no per-blob metadata fetch).
- **Client-side window filter** as pages stream: inclusive on both bounds, either bound nullable (= unbounded), `.kestradirectory` markers skipped (files only, like the default impl).
- **Bounded-concurrency deletes** (fixed 16-worker pool per call; Azure has no multi-delete request). Individual 404s tolerated (already gone = success); other `BlobStorageException`s wrapped in `IOException`.
- **`dryRun`** returns matched URIs without deleting; **missing prefix** yields an empty list.
- API calls scale with listing pages, not object count.

Also bumps `kestraVersion` to `2.0.0-SNAPSHOT` (first core build containing the interface method, kestra-io/kestra#16332) which requires the Java 25 toolchain and an explicit allure-junit5 pin (no longer managed by the platform BOM).

## Tests

`AzureStoragePurgeTest` (8 tests): in-window deletion + returned URIs, out-of-window preservation, dry-run no-op, missing prefix → empty, null start/end/both bounds, sibling-prefix isolation.

Local run fails on `CredentialUnavailableException` only (secrets are CI-injected); compilation against `2.0.0-SNAPSHOT` verified locally.

fixes: https://github.com/kestra-io/storage-azure/issues/109

🤖 Generated with [Claude Code](https://claude.com/claude-code)